### PR TITLE
add missing if

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ See `attributes/default.rb` for default values.
 - `node['resolver']['nameservers']` - Required, an array of nameserver IP address strings; the default is an empty array, and the default recipe will not change resolv.conf if this is not set. See **Usage**.
 - `node['resolver']['options']` - a hash of resolv.conf options. See **Usage** for examples.
 - `node['resolver']['domain']` - Local domain name. if `nil`, the domain is determined from the local hostname returned by `gethostname(2)`.
+- `node['resolver']['deactivate_resolveconf'] - Disable resolveconf management of `/etc/resolv.conf` by unlinking it. Useful on Ubuntu system so change managedment is rebootable. Default `false`.
 
 ## Recipes
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,3 +20,4 @@ default['resolver']['search'] = node['domain']
 default['resolver']['domain'] = nil
 default['resolver']['nameservers'] = []
 default['resolver']['options'] = {}
+default['resolver']['deactivate_resolvconf'] = false

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -36,7 +36,7 @@ else
     mode '0644'
     # This syntax makes the resolver sub-keys available directly
     variables node['resolver']
-    force_unlink node['resolver']['deactivate_resolvconf']
+    force_unlink if node['resolver']['deactivate_resolvconf']
   end
   t.atomic_update false if docker_guest?
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -36,7 +36,7 @@ else
     mode '0644'
     # This syntax makes the resolver sub-keys available directly
     variables node['resolver']
-    force_unlink if node['resolver']['deactivate_resolvconf']
+    force_unlink node['resolver']['deactivate_resolvconf']
   end
   t.atomic_update false if docker_guest?
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -36,6 +36,7 @@ else
     mode '0644'
     # This syntax makes the resolver sub-keys available directly
     variables node['resolver']
+    force_unlink node['resolver']['deactivate_resolvconf']
   end
   t.atomic_update false if docker_guest?
 end


### PR DESCRIPTION
Pretty sure the expected behavior for this PR is to run force_unlink if `node['resolver']['deactivate_resolveconf']` is not false - which means we need an if here.